### PR TITLE
Feature/data and programmatic navigation

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const Autoroutes = {
     tagName: 'router-link',
     scriptsClass: 'autoroutes-script',
     debug: true,
-    data: null
+    draftData: null
 }
 
 // Some methods must be immutable
@@ -132,7 +132,7 @@ function navigate(route, data) {
     const fixedPath = route.charAt(0) === '/' ? route : '/' + route; // Allows to omit leading "/"
     NAVIGATION_EVENT.path = fixedPath;
 
-    const fixedData = data !== undefined ? data : Autoroutes.data;
+    const fixedData = data !== undefined ? data : Autoroutes.draftData;
     history.pushState(fixedData, '', fixedPath);
 
     // Ensure no data might be accidentally added in next navigation
@@ -143,7 +143,7 @@ function navigate(route, data) {
 }
 
 function setData(data = {}) {
-    Autoroutes.data = data;
+    Autoroutes.draftData = data;
 }
 
 function getData() {

--- a/index.js
+++ b/index.js
@@ -129,15 +129,14 @@ async function mountView(route) {
 function navigate(route, data = {}) {
     const fixedPath = route.charAt(0) === '/' ? route : '/' + route; // Allows to omit leading "/"
     NAVIGATION_EVENT.path = fixedPath;
-    history.pushState({data}, '', fixedPath);
+    history.pushState(data, '', fixedPath);
 
     document.dispatchEvent(NAVIGATION_EVENT);
     mountView(route)
 }
 
 function getData() {
-    const state = history.state !== null ? history.state.data : null;
-    return state;
+    return history.state;
 }
 
 


### PR DESCRIPTION
It is now possible to use `Autoroutes.navigate(route, data)` directly in the code.
Also added the possibility to retrieve navigation data on current `history.state` using `Autoroutes.getData()` to give a single API for the developers to interact with. But also can set draft data for next navigation using `Autoroutes.setData(data)` and retrieve it with `Autoroutes.draftData`. This data is discarded once an Autoroutes *navigation* is triggered